### PR TITLE
Bump the node-glob dep to get "ignore" option

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
  "name": "glob-expand",
  "description": "A sync glob / minimatch / RegExp call with a gruntjs -like `expand` of patterns, with minimum depepndencies. Derived from gruntjs's v0.4.1 `file.expand`",
- "version": "0.0.2",
+ "version": "0.1.0",
  "homepage": "https://github.com/anodynos/node-glob-expand",
  "author": {
   "name": "Agelos Pikoulas",
@@ -35,7 +35,7 @@
   "node": "*"
  },
  "dependencies": {
-   "glob": "~3.1.21",
+   "glob": "~4.4.2",
    "lodash": "1.2.x"
  },
  "devDependencies": {


### PR DESCRIPTION
It can be much more performant to do negations with the new `ignore` options rather than a negation pattern. This is because all patterns are normally union-ed together, so there was no way to "short-circuit" and stop walking a directory tree that you wanted to skip (like a very large `node_modules/` folder).

Also, `ignore` is easier to understand (see all the [negation issues on the repo](https://github.com/isaacs/node-glob/search?utf8=%E2%9C%93&q=negation&type=Issues)). Plus v5/v6 of node-glob is deprecating/killing negation patterns anyway ([this](https://github.com/isaacs/node-glob#negation) and [this](https://github.com/isaacs/node-glob#comments-and-negation)).

